### PR TITLE
Bump heimdalljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "findup-sync": "^0.2.1",
     "handlebars": "^4.0.4",
-    "heimdalljs": "^0.1.2",
+    "heimdalljs": "^0.2.0",
     "mime": "^1.2.11",
     "promise-map-series": "^0.2.1",
     "quick-temp": "^0.1.2",


### PR DESCRIPTION
- [ ] blocked on heimdall 0.1.4 (see heimdalljs/heimdalljs-lib#3)
- [ ] run tests after heimdall 0.1.4 released
