### PR TITLE
Update github repo, homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/broccolijs/broccoli"
+    "url": "https://github.com/ember-cli/broccoli"
   },
-  "homepage": "https://github.com/broccolijs/broccoli",
+  "homepage": "https://github.com/ember-cli/broccoli",
   "dependencies": {
     "findup-sync": "^0.2.1",
     "handlebars": "^4.0.4",


### PR DESCRIPTION
The [npmjs.org site](https://www.npmjs.com/package/ember-cli-broccoli) links to github.com/broccolijs/broccoli for the `ember-cli-broccoli` package. This change to package.json should make it so that npmjs.org links here instead.
